### PR TITLE
Add flags for gcc unix detection in compiler_port.h

### DIFF
--- a/compiler_port.h
+++ b/compiler_port.h
@@ -106,7 +106,7 @@ typedef unsigned int uint_t;
    #define PRIXSIZE "X"
    #define PRIuTIME "lu"
 //Linux GCC compiler
-#elif defined(__linux__)
+#elif defined(__linux__) | defined(__unix__)
    #define PRIuSIZE "zu"
    #define PRIXSIZE "zX"
    #define PRIuTIME "lu"


### PR DESCRIPTION
compiler_port.h failed to create proper printf symbols for gcc on FreeBSD. The macro setting it considered linux only, but not unix.